### PR TITLE
Space missing.

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -12,7 +12,7 @@ Issuing Punishments
 +-----------+----------------------------------------+
 | eBan      | /eban [username] (reason) (duration)   |
 +-----------+----------------------------------------+
-| Mute      | /mute [username] (duration)           |
+| Mute      | /mute [username] (duration)            |
 +-----------+----------------------------------------+
 | Alts      | /e(history/alternative) [username]     |
 +-----------+----------------------------------------+


### PR DESCRIPTION

Probable cause of "Issuing punishments" tab not being displayed.


![Adnotacja 2022-09-02 015920](https://user-images.githubusercontent.com/81315830/188031817-85a9b6b7-98ec-464d-b61d-ba5e3a359eec.jpg)
